### PR TITLE
Version 1.0.8

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -650,3 +650,13 @@ tasks:
           task sf-dmm-test
           task sf-dfl-test
         fi
+
+  health-check:
+    desc: "Perform health check after files generation"
+    cmds:
+      - echo "Health check performed succesfully !"
+    preconditions:
+      - sh: "[ ! -d _docker-components  ]"
+        msg: "_docker-components folder not removed !"
+      - sh: "[ -f docker-compose_{{.CLI_ARGS}}.yml ]"
+        msg: "docker-compose file missing"


### PR DESCRIPTION
**Testing unitaire**

**Commande ajoutée:**
- health-check

**Description de la commande:**

- Verifie la non présence du dossier _docker-components
- Verifie la présence du fichier docker-compose.yml correspondant au CLI-ARGS fourni

**Utilisation de la commande:**

Après une commande task generate-docker-compose pour une config mariadb

`task health-check -- maria`

**TODOS et améliorations:**

Harmoniser le nom du param pour une configuration pour mariadb
( param generation != suffixe ajouté au nom de fichier )
