### PR TITLE
Version 1.0.9 : Fix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,33 @@
+# @author : Julien Pechberty
+#
+# https://help.github.com/en/actions
+name: setup symfony prohect TaskFile Testing
+on: pull_request
+#  push:
+#    branches:
+#      - testing-ci
+
+jobs:
+  testing:
+    name: Testing on ${{matrix.os}}
+    runs-on: ${{matrix.os}}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        #os: [ubuntu-latest, windows-latest, macos-latest]
+        sgbd: [mariadb,mysql5,mysql8,mongodb]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Génération du docker-compose pour ${{matrix.sgbd}}
+        run: |
+          task generate-docker-compose-cli -- ${{matrix.sgbd}}
+      - name: Health checking
+        run: |
+          task health-check -- ${{matrix.sgbd}}

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -106,11 +106,11 @@ tasks:
     cmds:
       - task: create-components-dir
       - |
-        echo "Choose your database system ? [mariadb/mysql5/mongodb] :"
+        echo "Choose your database system ? [mariadb/mysql5/mysql8/mongodb] :"
         read CONFIRM
         case $CONFIRM in 
           mariadb)
-            task create-maria-env;;
+            task create-mariadb-env;;
           mysql5)
             task create-mysql5-env;;
           mysql8)
@@ -388,32 +388,32 @@ tasks:
     cmds:
       - task: generate-file
         vars:
-          DOCKER_FILENAME: docker-compose_maria.yml
+          DOCKER_FILENAME: docker-compose_mariadb.yml
       - task: add-component
         vars:
           SRC_COMP_FILENAME: _docker-init.yml
           DEST_COMP_FILENAME: _docker-init.yml
-          DEST_DOCKER_COMPOSE_FILE: docker-compose_maria.yml
+          DEST_DOCKER_COMPOSE_FILE: docker-compose_mariadb.yml
       - task: add-component
         vars:
           SRC_COMP_FILENAME: services/_mariadb.yml
           DEST_COMP_FILENAME: _mariadb.yml
-          DEST_DOCKER_COMPOSE_FILE: docker-compose_maria.yml
+          DEST_DOCKER_COMPOSE_FILE: docker-compose_mariadb.yml
       - task: add-component
         vars:
           SRC_COMP_FILENAME: services/_phpmyadmin.yml
           DEST_COMP_FILENAME: _phpmyadmin.yml
-          DEST_DOCKER_COMPOSE_FILE: docker-compose_maria.yml
+          DEST_DOCKER_COMPOSE_FILE: docker-compose_mariadb.yml
       - task: add-component
         vars:
           SRC_COMP_FILENAME: services/_mailer.yml
           DEST_COMP_FILENAME: _mailer.yml
-          DEST_DOCKER_COMPOSE_FILE: docker-compose_maria.yml
+          DEST_DOCKER_COMPOSE_FILE: docker-compose_mariadb.yml
       - task: add-component
         vars:
           SRC_COMP_FILENAME: _docker-volumes.yml
           DEST_COMP_FILENAME: _docker-volumes.yml
-          DEST_DOCKER_COMPOSE_FILE: docker-compose_maria.yml
+          DEST_DOCKER_COMPOSE_FILE: docker-compose_mariadb.yml
     vars:
       UUID:
         sh: uuidgen | tr -d -

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -122,6 +122,25 @@ tasks:
         esac
       - task: remove-components-dir
 
+  generate-docker-compose-cli:
+    desc: "Create ready to use docker-compose.yml file in one line declaration with cli args"
+    cmds:
+      - task: create-components-dir
+      - |
+        case {{.CLI_ARGS}} in 
+          mariadb)
+            task create-mariadb-env;;
+          mysql5)
+            task create-mysql5-env;;
+          mysql8)
+            task create-mysql8-env;;
+          mongodb)
+            task create-mongodb-env;;
+          *)
+              echo -n "unknown";;
+        esac
+      - task: remove-components-dir
+
   ## === 🎛️  SYMFONY ===============================================
 
   sf-start:
@@ -489,37 +508,37 @@ tasks:
         sh: uuidgen | tr -d -
 
 
-  create-mongo-env:
+  create-mongodb-env:
     desc: "Create MongoDb Docker-compose recipe"
     cmds:
       - task: generate-file
         vars:
-          DOCKER_FILENAME: docker-compose_mongo.yml
+          DOCKER_FILENAME: docker-compose_mongodb.yml
       - task: add-component
         vars:
           SRC_COMP_FILENAME: _docker-init.yml
           DEST_COMP_FILENAME: _docker-init.yml
-          DEST_DOCKER_COMPOSE_FILE: docker-compose_mongo.yml
+          DEST_DOCKER_COMPOSE_FILE: docker-compose_mongodb.yml
       - task: add-component
         vars:
           SRC_COMP_FILENAME: services/_mongo.yml
           DEST_COMP_FILENAME: _mongo.yml
-          DEST_DOCKER_COMPOSE_FILE: docker-compose_mongo.yml
+          DEST_DOCKER_COMPOSE_FILE: docker-compose_mongodb.yml
       - task: add-component
         vars:
           SRC_COMP_FILENAME: services/_mongo-express.yml
           DEST_COMP_FILENAME: _mongo-express.yml
-          DEST_DOCKER_COMPOSE_FILE: docker-compose_mongo.yml
+          DEST_DOCKER_COMPOSE_FILE: docker-compose_mongodb.yml
       - task: add-component
         vars:
           SRC_COMP_FILENAME: services/_mailer.yml
           DEST_COMP_FILENAME: _mailer.yml
-          DEST_DOCKER_COMPOSE_FILE: docker-compose_mongo.yml
+          DEST_DOCKER_COMPOSE_FILE: docker-compose_mongodb.yml
       - task: add-component
         vars:
           SRC_COMP_FILENAME: _docker-volumes.yml
           DEST_COMP_FILENAME: _docker-volumes.yml
-          DEST_DOCKER_COMPOSE_FILE: docker-compose_mongo.yml
+          DEST_DOCKER_COMPOSE_FILE: docker-compose_mongodb.yml
     vars:
       UUID:
         sh: uuidgen | tr -d -


### PR DESCRIPTION
**Fonctionnalités ajoutées**

Ajout du fichier de test CI Github Actions: Permet de tester la génération du fichier docker-compose.yml sur les différents OS et pour tous les SGBD fournis.

> Attention le CI est paramétré pour s'exécuter lors des pull requests et ne teste pas l'OS Windows pour le moment, car en attente de patch pour `uuidgen` .

**Commandes:**

- `generate-docker-compose-cli` -> execute le même traitement que `generate-docker-compose` sauf qu'elle utilise les arguments fournies a la commande pour générer la bonne config. (Exemple: `generate-docker-compose-cli -- mariadb`)

> Cette commande permet une execution dans le workflows github action

**Patch correctif**

**Ce qui a été corrigé:**

- Typo sur le nom de la commande create-env-mariadb lors l'appel de cette dernière par la commande generate-docker-compose
- Typo sur le nom de la commande create-env-mongodb lors l'appel de cette dernière par la commande generate-docker-compose
- Harmonisation du nom de fichier docker-compose généré pour une config mariadb avec le param a donné à la commande generate-docker-compose et health-check
